### PR TITLE
Create job crud file upload

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -31,6 +31,7 @@ class JobController extends Controller
 
     //Store job data
     public function  store(Request $request) {
+        // dd($request->file('logo')->store());
         // dd($request->all());
         //validation
         $formFields = $request->validate([
@@ -42,6 +43,12 @@ class JobController extends Controller
             'tags' => 'required',       
             'description' => 'required',
         ]);
+        // if an image is submitted, (request has file called 'logo')
+        if($request->hasFile('logo') ){
+            // add 'logo' to formFields (like above) and set it the path, and store it in a folder called 'logos'
+            $formFields['logo'] = $request->file('logo')->store('logos');
+
+        }
 
         Job::create($formFields); // create the job in the database using the Job model. 
 

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -46,7 +46,7 @@ class JobController extends Controller
         // if an image is submitted, (request has file called 'logo')
         if($request->hasFile('logo') ){
             // add 'logo' to formFields (like above) and set it the path, and store it in a folder called 'logos'
-            $formFields['logo'] = $request->file('logo')->store('logos');
+            $formFields['logo'] = $request->file('logo')->store('logos', 'public');
 
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         //
-        Model::unguard();
+        Model::unguard();   
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('FILESYSTEM_DISK', 'local'),
+    'default' => env('FILESYSTEM_DISK', 'public'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2024_02_01_202925_create_jobs_table.php
+++ b/database/migrations/2024_02_01_202925_create_jobs_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('jobs', function (Blueprint $table) {
             $table->id();
             $table->string('title');
+            $table->string('logo')->nullable(); // nullable means if null is allowed. If no image is specified then its fine, it will continue                     
             $table->string('tags');
             $table->string('company');
             $table->string('location');

--- a/resources/views/components/job-card.blade.php
+++ b/resources/views/components/job-card.blade.php
@@ -5,7 +5,8 @@
     <div class="flex">
         <img
             class="hidden w-48 mr-6 md:block"
-            src="{{asset('images/no-image.png')}}"
+            {{-- if image set as image path, else set as default image --}}
+            src="{{$job->logo ? asset('storage/' . $job->logo) : asset('images/no-image.png')}}"
             alt=""
         />
         <div>

--- a/resources/views/jobs/create.blade.php
+++ b/resources/views/jobs/create.blade.php
@@ -9,7 +9,7 @@
             <p class="mb-4">Post a gig to find a developer</p>
         </header>
 
-        <form method="POST" action="/jobs">
+        <form method="POST" action="/jobs" enctype="multipart/form-data">
             {{-- csrf is a laravel directive to prevent cross site scripting attacks. Use everytime with POST --}}
             @csrf 
             <div class="mb-6">
@@ -24,7 +24,8 @@
                     name="company"
                     value="{{old('company')}}"
                 />
-                @error('company')
+                {{-- error is same as name --}}
+                @error('company')  
                     <p class="text-red-500 text-xs mt-1">{{$message}}</p>
                 @enderror
             </div>
@@ -113,7 +114,7 @@
                 @enderror
             </div>
 
-            {{-- <div class="mb-6">
+            <div class="mb-6">
                 <label for="logo" class="inline-block text-lg mb-2">
                     Company Logo
                 </label>
@@ -122,7 +123,11 @@
                     class="border border-gray-200 rounded p-2 w-full"
                     name="logo"
                 />
-            </div> --}}
+
+                @error('logo')
+                <p class="text-red-500 text-xs mt-1">{{$message}}</p>
+            @enderror
+            </div>
 
             <div class="mb-6">
                 <label

--- a/resources/views/jobs/show.blade.php
+++ b/resources/views/jobs/show.blade.php
@@ -13,7 +13,8 @@
         >
             <img
                 class="w-48 mr-6 mb-6"
-                src="{{asset('/images/no-image.png')}}"
+                {{-- if image set as image path, else set as default image --}}
+                src="{{$job->logo ? asset('storage/' . $job->logo) : asset('images/no-image.png')}}"
                 alt=""
             />
 


### PR DESCRIPTION
User can upload a logo image with their job posting, and the path will be stored on the database. The image is displayed next to their job posting on the main page, and on the single job posting page. If no image is uploaded, a default image is displayed. 